### PR TITLE
[Feature] 로그인 전 이용약관/개인정보 처리 방침 동의

### DIFF
--- a/app/src/main/java/com/upf/memorytrace_android/ui/login/LoginFragment.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/ui/login/LoginFragment.kt
@@ -15,6 +15,8 @@ import com.kakao.sdk.user.UserApiClient
 import com.upf.memorytrace_android.R
 import com.upf.memorytrace_android.ui.base.BaseFragment
 import com.upf.memorytrace_android.databinding.FragmentLoginBinding
+import com.upf.memorytrace_android.extension.setOnDebounceClickListener
+import com.upf.memorytrace_android.util.showDialog
 
 
 internal class LoginFragment : BaseFragment<LoginViewModel, FragmentLoginBinding>() {
@@ -27,12 +29,12 @@ internal class LoginFragment : BaseFragment<LoginViewModel, FragmentLoginBinding
     }
 
     private fun initViews() {
-        binding.btnKakaoLogin.setOnClickListener {
-            loginWithKakao()
+        binding.btnKakaoLogin.setOnDebounceClickListener {
+            showAgreeDialog { loginWithKakao() }
         }
 
-        binding.btnGoogleLogin.setOnClickListener {
-            loginWithGoogle()
+        binding.btnGoogleLogin.setOnDebounceClickListener {
+            showAgreeDialog { loginWithGoogle() }
         }
     }
 
@@ -115,6 +117,20 @@ internal class LoginFragment : BaseFragment<LoginViewModel, FragmentLoginBinding
                     Log.w(TAG, "signInWithCredential:failure", task.exception)
                 }
             }
+    }
+
+    private fun showAgreeDialog(
+        onAgree: () -> Unit
+    ) {
+        context?.let {
+            showDialog(
+                it,
+                "개인정보 수집/이용 약관 동의",
+                "계속 하시면 개인정보 수집 및 이용 약관에 동의하는 것으로 간주합니다.\n로그인 하시겠습니까?",
+                "확인",
+                onAgree
+            )
+        }
     }
 
 

--- a/app/src/main/java/com/upf/memorytrace_android/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/ui/login/LoginViewModel.kt
@@ -32,4 +32,18 @@ internal class LoginViewModel : BaseViewModel() {
             }
         }
     }
+
+    fun showTermsOfServiceFragment() {
+        showTermsFragment(1)
+    }
+
+    fun showTermsOfPrivacyFragment() {
+        showTermsFragment(2)
+    }
+
+    private fun showTermsFragment(terms: Int) {
+        if (terms != 1 && terms != 2) return
+        navDirections.value =
+            LoginFragmentDirections.actionLoginFragmentToTermsFragment(terms)
+    }
 }

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:app="http://schemas.android.com/apk/res-auto">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
 
@@ -8,12 +9,13 @@
             type="com.upf.memorytrace_android.ui.login.LoginViewModel" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:padding="@dimen/default_padding_24">
 
         <TextView
+            android:id="@+id/logo_duckz"
             style="@style/GmarketBold24"
             android:layout_width="wrap_content"
             android:text="@string/duck_z"
@@ -21,6 +23,34 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/btn_term_service"
+            onDebounceClick="@{() -> viewModel.showTermsOfServiceFragment()}"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:padding="3dp"
+            android:text="이용약관"
+            android:textColor="@color/gray04"
+            app:layout_constraintBottom_toTopOf="@id/btn_kakao_login"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.498"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/logo_duckz"
+            app:layout_constraintVertical_bias="0.665" />
+
+        <Button
+            onDebounceClick="@{() -> viewModel.showTermsOfPrivacyFragment()}"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            android:padding="3dp"
+            android:text="개인정보 처리 방침"
+            android:textColor="@color/gray04"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btn_term_service" />
 
         <LinearLayout
             android:id="@+id/btn_kakao_login"

--- a/app/src/main/res/navigation/nav.xml
+++ b/app/src/main/res/navigation/nav.xml
@@ -38,6 +38,10 @@
             android:id="@+id/action_loginFragment_to_writeFragment"
             app:destination="@id/writeFragment" />
 
+        <action
+            android:id="@+id/action_loginFragment_to_termsFragment"
+            app:destination="@+id/termsFragment" />
+
     </fragment>
 
     <fragment


### PR DESCRIPTION
## 요약
- 임시로 로그인 화면에서 이용약관/개인정보 처리 방침에 동의할 수 있도록 했습니다.

## 작업사항
- 두 버튼을 노골적으로 드러내고, 로그인 버튼을 누르면 동의하는 것으로 간주한다는 다이얼로그를 한 번 띄우도록 했습니다.

## 참조 
- closed #82 