### PR TITLE
[Feature][#86] Crachlytics 에러 로깅

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">

--- a/app/src/main/java/com/upf/memorytrace_android/api/model/BaseResponse.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/api/model/BaseResponse.kt
@@ -22,16 +22,4 @@ open class BaseResponse<out T>(
             return Gson().fromJson(jsonObject, BaseResponse::class.java)
         }
     }
-
-    fun getOrThrow(): T {
-        if (isSuccess) {
-            if (data == null) {
-                throw Throwable("success : $responseMessage")
-            } else {
-                return data
-            }
-        } else {
-            throw IllegalAccessException(responseMessage)
-        }
-    }
 }

--- a/app/src/main/java/com/upf/memorytrace_android/api/util/interceptor/StatusInterceptor.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/api/util/interceptor/StatusInterceptor.kt
@@ -7,6 +7,7 @@ import com.upf.memorytrace_android.api.util.StatusError
 import okhttp3.Interceptor
 import okhttp3.Response
 import java.io.IOException
+import java.lang.Exception
 
 class StatusInterceptor : Interceptor {
     @Throws(IOException::class)
@@ -15,10 +16,19 @@ class StatusInterceptor : Interceptor {
         val response = chain.proceed(request)
         //todo: 더 좋은 방법을 찾아볼 것(https://github.com/square/okhttp/issues/1240#issuecomment-330813274)
         val body = response.peekBody(Long.MAX_VALUE)
-        val gson = GsonBuilder().registerTypeAdapter(
-            BaseResponse::class.java,
-            BaseResponse.Deserializer()
-        ).create()
+        val gson = try {
+            GsonBuilder().registerTypeAdapter(
+                BaseResponse::class.java,
+                BaseResponse.Deserializer()
+            ).create()
+        } catch (e: Exception) {
+            val logMessage = "url : ${request.url}, body : ${request.body}, responseBody : $body"
+            FirebaseCrashlytics.getInstance().run {
+                log(logMessage)
+                recordException(e)
+            }
+            return response
+        }
         val data: BaseResponse<*> = gson.fromJson(body.string(), BaseResponse::class.java)
         if (!data.isSuccess) {
             val logMessage = "${data.responseMessage}, url : ${request.url}, body : ${request.body}"

--- a/app/src/main/java/com/upf/memorytrace_android/api/util/interceptor/StatusInterceptor.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/api/util/interceptor/StatusInterceptor.kt
@@ -11,7 +11,8 @@ import java.io.IOException
 class StatusInterceptor : Interceptor {
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
-        val response = chain.proceed(chain.request())
+        val request = chain.request()
+        val response = chain.proceed(request)
         //todo: 더 좋은 방법을 찾아볼 것(https://github.com/square/okhttp/issues/1240#issuecomment-330813274)
         val body = response.peekBody(Long.MAX_VALUE)
         val gson = GsonBuilder().registerTypeAdapter(
@@ -20,12 +21,14 @@ class StatusInterceptor : Interceptor {
         ).create()
         val data: BaseResponse<*> = gson.fromJson(body.string(), BaseResponse::class.java)
         if (!data.isSuccess) {
-            FirebaseCrashlytics.getInstance().log(data.responseMessage)
-            FirebaseCrashlytics.getInstance().recordException(StatusError(data))
+            val logMessage = "${data.responseMessage}, url : ${request.url}, body : ${request.body}"
+            FirebaseCrashlytics.getInstance().run {
+                log(logMessage)
+                recordException(StatusError(data))
+            }
             if (data.responseMessage.isBlank()) throw IOException()
             throw StatusError(data)
         }
         return response
     }
-
 }

--- a/app/src/main/java/com/upf/memorytrace_android/log/ExceptionLogger.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/log/ExceptionLogger.kt
@@ -1,0 +1,6 @@
+package com.upf.memorytrace_android.log
+
+interface ExceptionLogger {
+
+    fun logException(e: Exception)
+}

--- a/app/src/main/java/com/upf/memorytrace_android/log/FirebaseExceptionLogger.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/log/FirebaseExceptionLogger.kt
@@ -1,0 +1,12 @@
+package com.upf.memorytrace_android.log
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+
+class FirebaseExceptionLogger : ExceptionLogger {
+    override fun logException(e: Exception) {
+        FirebaseCrashlytics.getInstance().run {
+            e.message?.let { log(it) }
+            recordException(e)
+        }
+    }
+}

--- a/app/src/main/java/com/upf/memorytrace_android/log/LoggerModule.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/log/LoggerModule.kt
@@ -1,0 +1,14 @@
+package com.upf.memorytrace_android.log
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+class LoggerModule {
+
+    @Provides
+    fun providesExceptionLogger(): ExceptionLogger = FirebaseExceptionLogger()
+}

--- a/app/src/main/java/com/upf/memorytrace_android/ui/diary/comment/data/CommentRepositoryImpl.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/ui/diary/comment/data/CommentRepositoryImpl.kt
@@ -13,7 +13,7 @@ class CommentRepositoryImpl @Inject constructor(
 ): CommentRepository {
 
     override suspend fun fetchComments(diaryId: Int): List<Comment> {
-        return commentService.fetCommentList(diaryId).getOrThrow().flatMap {
+        return commentService.fetCommentList(diaryId).data!!.flatMap {
             mutableListOf<Comment>().apply {
                 val userId = MemoryTraceConfig.uid
                 add(it.toEntity(userId == it.userId))

--- a/app/src/main/java/com/upf/memorytrace_android/ui/diary/comment/domain/usecase/DeleteCommentUseCase.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/ui/diary/comment/domain/usecase/DeleteCommentUseCase.kt
@@ -1,5 +1,6 @@
 package com.upf.memorytrace_android.ui.diary.comment.domain.usecase
 
+import com.upf.memorytrace_android.log.ExceptionLogger
 import com.upf.memorytrace_android.ui.UiState
 import com.upf.memorytrace_android.ui.diary.comment.domain.Comment
 import com.upf.memorytrace_android.ui.diary.comment.domain.CommentRepository
@@ -8,6 +9,7 @@ import javax.inject.Inject
 
 class DeleteCommentUseCase@Inject constructor(
     private val commentRepository: CommentRepository,
+    private val exceptionLogger: ExceptionLogger
 ) {
 
     suspend operator fun invoke(diaryId: Int, commentId: Int): UiState<List<Comment>> {
@@ -16,6 +18,7 @@ class DeleteCommentUseCase@Inject constructor(
                 commentRepository.deleteComment(commentId)
                 UiState.Success(commentRepository.fetchComments(diaryId))
             } catch (e: Exception) {
+                exceptionLogger.logException(e)
                 UiState.Failure(e)
             }
         }

--- a/app/src/main/java/com/upf/memorytrace_android/ui/diary/comment/domain/usecase/FetchCommentUseCase.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/ui/diary/comment/domain/usecase/FetchCommentUseCase.kt
@@ -1,18 +1,21 @@
 package com.upf.memorytrace_android.ui.diary.comment.domain.usecase
 
+import com.upf.memorytrace_android.log.ExceptionLogger
 import com.upf.memorytrace_android.ui.UiState
 import com.upf.memorytrace_android.ui.diary.comment.domain.Comment
 import com.upf.memorytrace_android.ui.diary.comment.domain.CommentRepository
 import javax.inject.Inject
 
 class FetchCommentUseCase @Inject constructor(
-    private val commentRepository: CommentRepository
+    private val commentRepository: CommentRepository,
+    private val exceptionLogger: ExceptionLogger
 ) {
 
     suspend operator fun invoke(diaryId: Int): UiState<List<Comment>> {
         return try {
             UiState.Success(commentRepository.fetchComments(diaryId))
         } catch (e: Exception) {
+            exceptionLogger.logException(e)
             UiState.Failure(e)
         }
     }

--- a/app/src/main/java/com/upf/memorytrace_android/ui/diary/comment/domain/usecase/PostCommentUseCase.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/ui/diary/comment/domain/usecase/PostCommentUseCase.kt
@@ -1,5 +1,6 @@
 package com.upf.memorytrace_android.ui.diary.comment.domain.usecase
 
+import com.upf.memorytrace_android.log.ExceptionLogger
 import com.upf.memorytrace_android.ui.UiState
 import com.upf.memorytrace_android.ui.diary.comment.domain.Comment
 import com.upf.memorytrace_android.ui.diary.comment.domain.CommentRepository
@@ -7,6 +8,7 @@ import javax.inject.Inject
 
 class PostCommentUseCase @Inject constructor(
     private val commentRepository: CommentRepository,
+    private val exceptionLogger: ExceptionLogger
 ) {
 
     suspend operator fun invoke(
@@ -19,6 +21,7 @@ class PostCommentUseCase @Inject constructor(
                 postComment(parentCommentId, diaryId, content)
                 UiState.Success(commentRepository.fetchComments(diaryId))
             } catch (e: Exception) {
+                exceptionLogger.logException(e)
                 UiState.Failure(e)
             }
         }

--- a/app/src/main/java/com/upf/memorytrace_android/ui/diary/data/DiaryRepositoryImpl.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/ui/diary/data/DiaryRepositoryImpl.kt
@@ -15,7 +15,7 @@ class DiaryRepositoryImpl @Inject constructor(
 
     override suspend fun fetchDiary(diaryId: Int): DiaryDetail {
         return withContext(Dispatchers.IO) {
-            diaryService.fetchDiary(diaryId).getOrThrow().toEntry(MemoryTraceConfig.uid)!!
+            diaryService.fetchDiary(diaryId).data!!.toEntry(MemoryTraceConfig.uid)!!
         }
     }
 }

--- a/app/src/main/java/com/upf/memorytrace_android/ui/diary/detail/domain/FetchDiaryUseCase.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/ui/diary/detail/domain/FetchDiaryUseCase.kt
@@ -1,17 +1,20 @@
 package com.upf.memorytrace_android.ui.diary.detail.domain
 
+import com.upf.memorytrace_android.log.ExceptionLogger
 import com.upf.memorytrace_android.ui.UiState
 import com.upf.memorytrace_android.ui.diary.domain.DiaryRepository
 import javax.inject.Inject
 
 class FetchDiaryUseCase @Inject constructor(
-    private val diaryRepository: DiaryRepository
+    private val diaryRepository: DiaryRepository,
+    private val exceptionLogger: ExceptionLogger
 ) {
 
     suspend operator fun invoke(diaryId: Int): UiState<DiaryDetail> {
         return try {
             UiState.Success(diaryRepository.fetchDiary(diaryId))
         } catch (e: Exception) {
+            exceptionLogger.logException(e)
             UiState.Failure(e)
         }
     }

--- a/app/src/main/java/com/upf/memorytrace_android/ui/mypage/MypageFragment.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/ui/mypage/MypageFragment.kt
@@ -67,7 +67,7 @@ internal class MypageFragment : BaseFragment<MypageViewModel, FragmentMypageBind
         }
         observe(viewModel.showOssPage){ startActivity(Intent(requireActivity(), OssLicensesMenuActivity::class.java)) }
         observe(viewModel.sendEmail){
-            val content = "[문의정보]\n닉네임 : ${viewModel.name.value}\n가입정보 : ${viewModel.sns.value}\n버전정보 : ${viewModel.version.value}(${Build.VERSION.SDK_INT})\n\n"
+            val content = "[문의정보]\n닉네임 : ${viewModel.name.value}\nuid : ${viewModel.uid}\n가입정보 : ${viewModel.sns.value}\n버전정보 : ${viewModel.version.value}(${Build.VERSION.SDK_INT})\n\n"
             startActivity(Intent(Intent.ACTION_SENDTO, Uri.parse("mailto:help.duck.z@gmail.com?body="+Uri.encode(content))))
         }
     }

--- a/app/src/main/java/com/upf/memorytrace_android/ui/mypage/MypageViewModel.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/ui/mypage/MypageViewModel.kt
@@ -20,6 +20,8 @@ internal class MypageViewModel : BaseViewModel() {
     val showOssPage = LiveEvent<Unit?>()
     val sendEmail = LiveEvent<Unit?>()
 
+    val uid = MemoryTraceConfig.uid
+
     init {
         name.value = MemoryTraceConfig.nickname
         sns.value = MemoryTraceConfig.sns

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <!-- Trust user added CAs while debuggable only -->
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>


### PR DESCRIPTION
## 요약
- `StatusInterceptor`에서 에러를 로깅하고 있으나, 비동기 처리의 응답값을 가로챘기 때문에 콜스택을 보는 것에 의미가 없습니다.
- 따라서 에러를 로깅하기 전, 어떤 요청이었는지 url 과 body 를 함께 로깅합니다.
  -  파이어베이스 콘솔에서 지속적으로 관찰되고 있는 `BaseResponse#Deserializer` 에 대한 에러도 원인을 파악하기 위해 로깅했습니다.
- `StatusInterceptor`에서 이런식으로 로깅을 하고 있는지 몰랐어서, `BaseResponse`에서 `getOrThrow()`를 만들어 사용하고 있었습니다. 비슷한 작업을 인터셉터에서 하고 있으니 제거했습니다.
  - 대신 응답이 success 일 때 data가 null 일 수 없는 응답인 경우에는 `data!!` 로 강제로 꺼내도록 했습니다. (내키진 않으나 좋은 방법이 생각나지 않습니다.)
- 리팩토링 한 Usecase 클래스들에서 에러를 잡는데, 이때도 로깅을 하기 위해서 `ExceptionLogger`라는 의존을 갖도록 했습니다.
  - 여기서 한 번 더 잡으면, 의미 있는 콜스택이 로깅되기 때문에 트러블슈팅이 용이할 것으로 예상됩니다. (아니려나 ..)
  - `data!!` 부분에서 문제가 생겨도 로깅이 가능합니다.
- `ExceptionLogger`는 로깅을 할 수 있는 인터페이스일 뿐, 구현체는 `FirebaseExceptionLogger`로 Crashlytics 를 사용해서 로깅을 합니다.
  - 추후 다른 로깅 라이브러리를 함께 사용하게 되면 쉽게 교체가 가능합니다.
## 참조 
- closed #86