### PR TITLE
[#88] 재촉하기 - pinchCnt 0일 때 로직 수정

### DIFF
--- a/app/src/main/java/com/upf/memorytrace_android/ui/diary/list/presentation/DiaryListFragment.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/ui/diary/list/presentation/DiaryListFragment.kt
@@ -147,9 +147,6 @@ class DiaryListFragment : BindingFragment<FragmentDiaryBinding>(R.layout.fragmen
                         is DiaryListViewModel.Event.SuccessPinch -> {
                             toast(getString(R.string.pinch_success_toast, event.turnUserName))
                         }
-                        is DiaryListViewModel.Event.NoPinchCount -> {
-                            toast(getString(R.string.pinch_no_pinch_count_toast))
-                        }
                         is DiaryListViewModel.Event.Error -> {
                             toast(event.errorMessage.takeIf { message ->
                                 message.isNotEmpty()

--- a/app/src/main/java/com/upf/memorytrace_android/ui/diary/list/presentation/DiaryListViewModel.kt
+++ b/app/src/main/java/com/upf/memorytrace_android/ui/diary/list/presentation/DiaryListViewModel.kt
@@ -32,7 +32,6 @@ class DiaryListViewModel @Inject constructor(
         data class Setting(val bookId: Int) : Event()
         data class Error(val errorMessage: String) : Event()
         data class SuccessPinch(val turnUserName: String) : Event()
-        object NoPinchCount: Event()
     }
 
     private val _uiEvent = MutableEventLiveData<Event>()
@@ -187,11 +186,6 @@ class DiaryListViewModel @Inject constructor(
     }
 
     private fun pinch() {
-        val pinchInfo = diaryHeaderUiModel.value
-        if (pinchInfo.pinchCount < 1) {
-            _uiEvent.event = Event.NoPinchCount
-            return
-        }
         viewModelScope.launch {
             _diaryHeaderUiModel.update { it.copy(isLoading = true) }
             pinchUseCase(bookId)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,7 +122,6 @@
     <string name="header_othder_turn_pinch_count">오늘 재촉 가능 횟수</string>
     <string name="header_othder_turn_pinch">재촉하기</string>
     <string name="pinch_success_toast">%s님이 일기를 쓰도록 재촉했어요!</string>
-    <string name="pinch_no_pinch_count_toast">재촉하기는 일기장당 하루 세번만 가능 해요!</string>
 
     <string name="sponsor_title">덕지를 잘 이용하고 계신가요?</string>
     <string name="sponsor_desc">덕지를 잘 쓰고 계시다면 \n서비스 유지를 위해 커피 한잔 값을 후원해 주세요!</string>


### PR DESCRIPTION
## 요약
- pinchCnt 가 0일때 api 를 호출하지 않는 로직을 수정했습니다.
- 턴이 돌아온지 8시간이 되지 않으면 pinchCnt 0, pinchable false 로 내려오기 때문에 api 를 찔러봐야 기회가 모두 소진된 것인지 8시간이 되지 않은 것인지 알 수 있기 때문입니다.

## 참조 
- #88
